### PR TITLE
Yandex OAuth 2.0 provider requires ' ' (space) as a scope separator

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -14,6 +14,11 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
+    protected $scopeSeparator = ' ';
+    
+    /**
+     * {@inheritdoc}
+     */
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase(


### PR DESCRIPTION
Dear Developers,

Thank you very much for the project!

Apparently, it seems the provider only supports a `space` character as a OAuth 2.0 scope separator, yet the current solution or [Provider](https://github.com/SocialiteProviders/Yandex/blob/master/Provider.php#L10) class inherits/states the [comma](https://github.com/laravel/socialite/blob/master/src/Two/AbstractProvider.php#L68) - request explicitly fails.

---

> `scope` - A list of permissions that the application currently needs, separated by a space. 

Source: [Yandex OAuth 2.0 docs (Google translated)](https://yandex-ru.translate.goog/dev/id/doc/dg/oauth/reference/auto-code-client.html?_x_tr_sl=ru&_x_tr_tl=en&_x_tr_hl=lt&_x_tr_pto=wapp#auto-code-client__get-code)

---

Best and kind regards